### PR TITLE
Se corrige la generación de HTML del contenido tipo Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@babel/core": "^7.12.3",
     "@material-ui/core": "^4.9.8",
     "@material-ui/icons": "^4.9.1",
+    "@uiw/react-markdown-preview": "^3.1.3",
     "axios": "^0.19.2",
     "dompurify": "^2.0.7",
     "dotenv": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@material-ui/core": "^4.9.8",
     "@material-ui/icons": "^4.9.1",
     "@uiw/react-markdown-preview": "^3.1.3",
-    "axios": "^0.19.2",
+    "axios": "^0.21.1",
     "dompurify": "^2.0.7",
     "dotenv": "^8.2.0",
     "gatsby": "^2.25.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@babel/core": "^7.12.3",
     "@material-ui/core": "^4.9.8",
     "@material-ui/icons": "^4.9.1",
+    "@uiw/react-markdown-preview": "^3.1.3",
     "axios": "^0.21.1",
     "dompurify": "^2.0.7",
     "dotenv": "^8.2.0",

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -9,8 +9,6 @@ import 'moment/locale/es';
 import Wrapper from '../styles/Post';
 import PostFooter from './PostFooter';
 import { Disqus } from 'gatsby-plugin-disqus';
-import ReactMarkdown from 'react-markdown'
-const gfm = require('remark-gfm')
 import MarkdownPreview from '@uiw/react-markdown-preview';
 
 const Post = ({

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -9,6 +9,9 @@ import 'moment/locale/es';
 import Wrapper from '../styles/Post';
 import PostFooter from './PostFooter';
 import { Disqus } from 'gatsby-plugin-disqus';
+import ReactMarkdown from 'react-markdown'
+const gfm = require('remark-gfm')
+import MarkdownPreview from '@uiw/react-markdown-preview';
 
 const Post = ({
   data: {
@@ -17,7 +20,7 @@ const Post = ({
 }) => {
   const [url, setUrl] = useState();
   const { id, slug, featured_media, createdAt, authors, content, title } = post;
-
+  console.log(content)
   useLayoutEffect(() => {
     setUrl(window.location.href);
   }, []);
@@ -43,10 +46,8 @@ const Post = ({
               Por: {authors.items[0].author.firstName}
             </p>
           </div>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: content,
-            }}
+          <MarkdownPreview 
+            source={content} 
           />
           {id && (
             <Disqus

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -9,15 +9,7 @@ import 'moment/locale/es';
 import Wrapper from '../styles/Post';
 import PostFooter from './PostFooter';
 import { Disqus } from 'gatsby-plugin-disqus';
-import ReactMarkdown from 'react-markdown';
-import PrismJS from 'prismjs';
-import 'prismjs/themes/prism-okaidia.css';
-
-const md = `
-  ~~~js
-  console.log('It works!');
-  ~~~
-`;
+import MarkdownPreview from '@uiw/react-markdown-preview';
 
 const Post = ({
   data: {
@@ -26,7 +18,7 @@ const Post = ({
 }) => {
   const [url, setUrl] = useState();
   const { id, slug, featured_media, createdAt, authors, content, title } = post;
-
+  console.log(content)
   useLayoutEffect(() => {
     setUrl(window.location.href);
   }, []);
@@ -56,9 +48,9 @@ const Post = ({
               Por: {authors.items[0].author.firstName}
             </p>
           </div>
-          <ReactMarkdown>
-            {content + md}
-          </ReactMarkdown>
+          <MarkdownPreview 
+            source={content} 
+          />
           {id && (
             <Disqus
               config={{

--- a/src/components/Post.js
+++ b/src/components/Post.js
@@ -18,7 +18,6 @@ const Post = ({
 }) => {
   const [url, setUrl] = useState();
   const { id, slug, featured_media, createdAt, authors, content, title } = post;
-  console.log(content)
   useLayoutEffect(() => {
     setUrl(window.location.href);
   }, []);


### PR DESCRIPTION
Se agrego react-markdown-preview para generar el HTML proveniente de contenido del Post con formato Markdown.

<img width="969" alt="Screen Shot 2021-07-28 at 21 36 14" src="https://user-images.githubusercontent.com/23038676/127422804-99b62b06-0388-4fec-89a3-36a5ad59a27d.png">
